### PR TITLE
refactored get article by id to include comment count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -48,14 +48,14 @@ describe("GET /api/articles/:articles_id", () => {
         const { article } = body;
         expect(article.article_id).toBe(1);
         expect(article).toMatchObject({
-          title: expect.any(String),
-          topic: expect.any(String),
-          author: expect.any(String),
-          article_id: expect.any(Number),
-          body: expect.any(String),
-          created_at: expect.any(String),
-          votes: expect.any(Number),
-          comment_count: expect.any(Number),
+          article_id: 1,
+          title: "Living in the shadow of a great man",
+          topic: "mitch",
+          author: "butter_bridge",
+          body: "I find this existence challenging",
+          created_at: "2020-07-09T20:11:00.000Z",
+          votes: 100,
+          comment_count: "11",
         });
       });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -55,25 +55,13 @@ describe("GET /api/articles/:articles_id", () => {
           body: expect.any(String),
           created_at: expect.any(String),
           votes: expect.any(Number),
+          comment_count: expect.any(Number),
         });
       });
   });
   test("400: responds with bad request if given wrong article_id", () => {
     return request(app)
       .get("/api/articles/article_5")
-
-      .expect(400)
-      .then(({ body: { msg } }) => {
-        expect(msg).toBe("bad request");
-      });
-  });
-  test("400: incorrect type, responds with bad request ", () => {
-    const updatedArticle1 = {
-      inc_votes: "string",
-    };
-    return request(app)
-      .patch("/api/articles/1")
-      .send(updatedArticle1)
       .expect(400)
       .then(({ body: { msg } }) => {
         expect(msg).toBe("bad request");
@@ -130,6 +118,18 @@ describe("PATCH /api/artices/:articled_id", () => {
           created_at: expect.any(String),
           votes: 0,
         });
+      });
+  });
+  test("400: incorrect type, responds with bad request ", () => {
+    const updatedArticle1 = {
+      inc_votes: "string",
+    };
+    return request(app)
+      .patch("/api/articles/1")
+      .send(updatedArticle1)
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("bad request");
       });
   });
   test("400: malformed body / missing required fields, responds with bad request ", () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -7,7 +7,6 @@ exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
   selectArticleById(article_id)
     .then((article) => {
-      console.log(article);
       res.status(200).send({ article });
     })
     .catch((err) => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -7,6 +7,7 @@ exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
   selectArticleById(article_id)
     .then((article) => {
+      console.log(article);
       res.status(200).send({ article });
     })
     .catch((err) => {

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -7,14 +7,23 @@ exports.selectArticleById = (article_id) => {
   if (isNaN(article_id)) {
     return Promise.reject({ status: 400, msg: "bad request" });
   }
-  return db.query(queryStr, queryValues).then(({ rows }) => {
-    if (!rows.length) {
+
+  let commentQueryStr = "SELECT * FROM comments WHERE article_id = $1";
+  const articlePromise = db.query(queryStr, queryValues);
+  const commentPromise = db.query(commentQueryStr, queryValues);
+  const promises = [articlePromise, commentPromise];
+  return Promise.all(promises).then((result) => {
+    const articleObj = result[0].rows[0];
+
+    if (result[0].rows.length) {
+      articleObj.comment_count = result[1].rows.length;
+    } else {
       return Promise.reject({
         status: 404,
         msg: `no article found for article_id ${article_id}`,
       });
     }
-    return rows[0];
+    return articleObj;
   });
 };
 

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -8,22 +8,17 @@ exports.selectArticleById = (article_id) => {
     return Promise.reject({ status: 400, msg: "bad request" });
   }
 
-  let commentQueryStr = "SELECT * FROM comments WHERE article_id = $1";
-  const articlePromise = db.query(queryStr, queryValues);
-  const commentPromise = db.query(commentQueryStr, queryValues);
-  const promises = [articlePromise, commentPromise];
-  return Promise.all(promises).then((result) => {
-    const articleObj = result[0].rows[0];
+  queryStr =
+    "SELECT articles.*, COUNT(comments.article_id) AS comment_count FROM articles LEFT JOIN comments on comments.article_id = articles.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id";
 
-    if (result[0].rows.length) {
-      articleObj.comment_count = result[1].rows.length;
-    } else {
+  return db.query(queryStr, queryValues).then((result) => {
+    if (!result.rows.length) {
       return Promise.reject({
         status: 404,
         msg: `no article found for article_id ${article_id}`,
       });
     }
-    return articleObj;
+    return result.rows[0];
   });
 };
 


### PR DESCRIPTION
- refactored test block to include comment count property
- refactored selectArticleById in the articles models to now return object with comment count property
- noticed a patcha article test block was accidently moved into get articles describe block during merge conflict so moved it back